### PR TITLE
Fixing bug: row missing after all of its cells were scrolled off the visible rect

### DIFF
--- a/DTGridView.m
+++ b/DTGridView.m
@@ -443,10 +443,7 @@ NSInteger intSort(id info1, id info2, void *context) {
 
 - (void)checkViews {
 		
-	if ([cellInfoForCellsOnScreen count] == 0) {
-		[self initialiseViews];
-		return;
-	}
+    [self initialiseViews];
 	
 	NSMutableDictionary *leftRightCells = [[NSMutableDictionary alloc] init];
 		


### PR DESCRIPTION
Fixing bug: row missing after all of its cells were scrolled off the visible rect.

This change may fix the following issue too: https://github.com/danielctull/DTGridView/issues/8
